### PR TITLE
Fixing compilation issue reported in issue #12

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Revision History for `enumlib`
 
+## Revision 0.0.2
+
+Fixed a compiler issue that was being caused by the fact that GroupList and permList were moved from tree_class.f90 to enumeration_types.f90 but were not made public in enumeration types.
+
 ## Revision 0.0.1
 
 This commit is to move the "extra" or "auxiliary" files in the src folder to the folder aux_src. These files may be useful for some users but are not necessary for the enumeration code to operate. We also updated the Makefile to reflect these changes, moved some types that aren't in enumeration_types.f90 but were declared inside specific programs so that the unit tests can run more smoothly, and added a README to the src and aux_src files.

--- a/src/enumeration_types.f90
+++ b/src/enumeration_types.f90
@@ -2,7 +2,7 @@ MODULE enumeration_types
 use num_types
 implicit none
 private
-public derivCryst, opList, LabelRotationList, RotPermList, maxLabLength
+public derivCryst, opList, LabelRotationList, RotPermList, maxLabLength, GroupList, permList
 
 integer, parameter :: maxLabLength = 500  ! maximum length of the character string labeling
 


### PR DESCRIPTION
Made GroupList and permList public inside of enumeration_types.f90 to reflect their relocation to that module.
