### PR TITLE
Allow large cells in POSCARs from makeStr.f90

### DIFF
--- a/aux_src/makeStr.f90
+++ b/aux_src/makeStr.f90
@@ -184,7 +184,7 @@ do istrN=strNi,strNf
    !GH write(foutput_unit,'("scale factor")')
    write(foutput_unit,'("1.00")')
    do i = 1,3
-      write(foutput_unit,'(3f12.8)') sLV(:,i)
+      write(foutput_unit,'(3(f12.8,1x))') sLV(:,i)
    enddo
    call matrix_inverse(sLV,sLVinv)
    write(13,'("New inverse after reduction",/,3(3(f7.3,1x),/))') (sLVinv(i,:),i=1,3) 


### PR DESCRIPTION
This allows lattice vectors to be printed with spaces (which allows/simplifies parsing) for large unit cells. Attaching example [struct_enum.out.log](https://github.com/msg-byu/enumlib/files/1740309/struct_enum.out.log) - rename to struct_enum.out. With the fix, POSCAR output looks like:
```
disordered str #: 1                                                             
1.00
  0.00000000 236.83340000   0.00000000
  0.00000000   0.00000000 236.83340000
236.83340000   0.00000000   0.00000000
  1   5
D
  0.42171227   0.37376751   0.30011329
  0.43256770   0.43875817   0.28519812
  0.41722624   0.50399374   0.29374493
  0.37091132   0.55288958   0.29905702
  0.36872232   0.55812968   0.23173809
  0.31546906   0.58678827   0.20162384
```
