### PR TITLE
Allow old algorithm (to get the degeneracies) to be enforced through command-line parameter

### DIFF
--- a/src/derivative_structure_generator.f90
+++ b/src/derivative_structure_generator.f90
@@ -1224,8 +1224,10 @@ CONTAINS
   !!  for range limitations.</dimension> </parameter>
   !!<parameter name="polya" regular="true">Logical flag for if the
   !!code is running the polya mode.</parameter>
+  !!<parameter name="oldAlgorithm" regular="true">Logical flag for if the
+  !!code is to use old algorithm no matter what.</parameter>
  SUBROUTINE gen_multilattice_derivatives(title, parLV, nDFull, dFull, k, nMin, nMax, pLatTyp, eps, full,&
-       & labelFull,digitFull,equivalencies, conc_check,cRange, polya)
+       & labelFull,digitFull,equivalencies, conc_check,cRange, polya, oldAlgorithm)
     integer, intent(in) :: k, nMin, nMax, nDFull
     integer             :: nD
     !Had to change character to 80 from 10 to match the definition in io_utils.read_input
@@ -1241,6 +1243,7 @@ CONTAINS
     logical, intent(in) :: conc_check
     integer, optional,intent(in)   :: cRange(:,:)
     logical, optional, intent(in) :: polya
+    logical, optional, intent(in) :: oldAlgorithm
     
     integer :: iD, i, ivol, LatDim, Scnt, Tcnt, iBlock, HNFcnt, status, iC, j
     integer, pointer, dimension(:,:,:) :: HNF => null(),SNF => null(), L => null(), R => null()
@@ -1483,7 +1486,9 @@ CONTAINS
                    ! efficient. Unless there are arrows present in the
                    ! enumeration or the multinomial of possible
                    ! arrangements is to large for enum3 to handle.
-                   if (any(site_res == 0) .and. (multinomial(iRange(iC,:)) < max_binomial) .and. (arrows .eqv. .false.)) then
+                   if (oldAlgorithm .or. (any(site_res == 0)&
+                         .and. (multinomial(iRange(iC,:)) < max_binomial)&
+                         .and. (arrows .eqv. .false.))) then
                       call generate_permutation_labelings(k,ivol,nD,rdRPList(iBlock)%perm,&
                            lm,iRange(iC,:),labelFull,digitFull,lab_degen,fixed_cells)
                       call write_labelings(k,ivol,nD,label,digit,iBlock,rdHNF,SNF,L,fixOp,Tcnt,&

--- a/src/derivative_structure_generator.f90
+++ b/src/derivative_structure_generator.f90
@@ -1224,10 +1224,10 @@ CONTAINS
   !!  for range limitations.</dimension> </parameter>
   !!<parameter name="polya" regular="true">Logical flag for if the
   !!code is running the polya mode.</parameter>
-  !!<parameter name="oldAlgorithm" regular="true">Logical flag for if the
-  !!code is to use old algorithm no matter what.</parameter>
+  !!<parameter name="origCrossOutAlgorithm" regular="true">Logical flag for if the
+  !!code is to use original cross out algorithm no matter what.</parameter>
  SUBROUTINE gen_multilattice_derivatives(title, parLV, nDFull, dFull, k, nMin, nMax, pLatTyp, eps, full,&
-       & labelFull,digitFull,equivalencies, conc_check,cRange, polya, oldAlgorithm)
+       & labelFull,digitFull,equivalencies, conc_check,cRange, polya, origCrossOutAlgorithm)
     integer, intent(in) :: k, nMin, nMax, nDFull
     integer             :: nD
     !Had to change character to 80 from 10 to match the definition in io_utils.read_input
@@ -1243,7 +1243,7 @@ CONTAINS
     logical, intent(in) :: conc_check
     integer, optional,intent(in)   :: cRange(:,:)
     logical, optional, intent(in) :: polya
-    logical, optional, intent(in) :: oldAlgorithm
+    logical, optional, intent(in) :: origCrossOutAlgorithm
     
     integer :: iD, i, ivol, LatDim, Scnt, Tcnt, iBlock, HNFcnt, status, iC, j
     integer, pointer, dimension(:,:,:) :: HNF => null(),SNF => null(), L => null(), R => null()
@@ -1486,7 +1486,7 @@ CONTAINS
                    ! efficient. Unless there are arrows present in the
                    ! enumeration or the multinomial of possible
                    ! arrangements is to large for enum3 to handle.
-                   if (oldAlgorithm .or. (any(site_res == 0)&
+                   if (origCrossOutAlgorithm .or. (any(site_res == 0)&
                          .and. (multinomial(iRange(iC,:)) < max_binomial)&
                          .and. (arrows .eqv. .false.))) then
                       call generate_permutation_labelings(k,ivol,nD,rdRPList(iBlock)%perm,&

--- a/src/driver.f90
+++ b/src/driver.f90
@@ -13,12 +13,18 @@ character(1) :: latTyp
 real(dp)  eps
 real(dp) :: parLV(3,3)
 
-character(80) title, fname
+character(80) title, fname, arg2
 logical fullLab,concCheck
+logical :: oldAlgorithm = .false.
 integer, pointer :: cRange(:,:)
 integer, pointer :: label(:,:)
 integer, pointer :: digit(:)
 integer, pointer :: equivalencies(:)
+
+if (iargc()>=2) then
+    call getarg(2,arg2)
+    read(arg2, '(L1)') oldAlgorithm
+endif
 
 if (iargc()>=1) then
    call getarg(1,fname)
@@ -29,6 +35,6 @@ call read_input(title,LatDim,parLV,nD,d,k,equivalencies,nMin,nMax,eps&
      &,fullLab,label,digit,fname,cRange,concCheck) ! Read in parent lattice vectors, etc.
 if (LatDim==3) then; latTyp='b';else;latTyp='s';endif
 call gen_multilattice_derivatives(title, parLV,nD,d,k,nMin,nMax,latTyp,eps,fullLab,&
-         label,digit,equivalencies,concCheck,cRange)
+         label,digit,equivalencies,concCheck,cRange, polya=.false., oldAlgorithm=oldAlgorithm)
 
 END PROGRAM driver

--- a/src/driver.f90
+++ b/src/driver.f90
@@ -15,7 +15,7 @@ real(dp) :: parLV(3,3)
 
 character(80) title, fname, arg2
 logical fullLab,concCheck
-logical :: oldAlgorithm = .false.
+logical :: origCrossOutAlgorithm = .false.
 integer, pointer :: cRange(:,:)
 integer, pointer :: label(:,:)
 integer, pointer :: digit(:)
@@ -23,7 +23,7 @@ integer, pointer :: equivalencies(:)
 
 if (iargc()>=2) then
     call getarg(2,arg2)
-    read(arg2, '(L1)') oldAlgorithm
+    read(arg2, '(L1)') origCrossOutAlgorithm
 endif
 
 if (iargc()>=1) then
@@ -35,6 +35,7 @@ call read_input(title,LatDim,parLV,nD,d,k,equivalencies,nMin,nMax,eps&
      &,fullLab,label,digit,fname,cRange,concCheck) ! Read in parent lattice vectors, etc.
 if (LatDim==3) then; latTyp='b';else;latTyp='s';endif
 call gen_multilattice_derivatives(title, parLV,nD,d,k,nMin,nMax,latTyp,eps,fullLab,&
-         label,digit,equivalencies,concCheck,cRange, polya=.false., oldAlgorithm=oldAlgorithm)
+         label,digit,equivalencies,concCheck,cRange, polya=.false.,&
+         origCrossOutAlgorithm=origCrossOutAlgorithm)
 
 END PROGRAM driver

--- a/src/driver_polya.f90
+++ b/src/driver_polya.f90
@@ -13,12 +13,18 @@ character(1) :: latTyp
 real(dp)  eps
 real(dp) :: parLV(3,3)
 
-character(80) title, fname
+character(80) title, fname, arg2
 logical fullLab,concCheck
+logical :: oldAlgorithm = .false.
 integer, pointer :: cRange(:,:)
 integer, pointer :: label(:,:)
 integer, pointer :: digit(:)
 integer, pointer :: equivalencies(:)
+
+if (iargc()>=2) then
+    call getarg(2,arg2)
+    read(arg2, '(L1)') oldAlgorithm
+endif
 
 if (iargc()>=1) then
    call getarg(1,fname)
@@ -29,6 +35,6 @@ call read_input(title,LatDim,parLV,nD,d,k,equivalencies,nMin,nMax,eps&
      &,fullLab,label,digit,fname,cRange,concCheck) ! Read in parent lattice vectors, etc.
 if (LatDim==3) then; latTyp='b';else;latTyp='s';endif
 call gen_multilattice_derivatives(title, parLV,nD,d,k,nMin,nMax,latTyp,eps,fullLab,&
-         label,digit,equivalencies,concCheck,cRange, polya=.true.)
+         label,digit,equivalencies,concCheck,cRange, polya=.true., oldAlgorithm=oldAlgorithm)
 
 END PROGRAM driver

--- a/src/driver_polya.f90
+++ b/src/driver_polya.f90
@@ -15,7 +15,7 @@ real(dp) :: parLV(3,3)
 
 character(80) title, fname, arg2
 logical fullLab,concCheck
-logical :: oldAlgorithm = .false.
+logical :: origCrossOutAlgorithm = .false.
 integer, pointer :: cRange(:,:)
 integer, pointer :: label(:,:)
 integer, pointer :: digit(:)
@@ -23,7 +23,7 @@ integer, pointer :: equivalencies(:)
 
 if (iargc()>=2) then
     call getarg(2,arg2)
-    read(arg2, '(L1)') oldAlgorithm
+    read(arg2, '(L1)') origCrossOutAlgorithm
 endif
 
 if (iargc()>=1) then
@@ -35,6 +35,7 @@ call read_input(title,LatDim,parLV,nD,d,k,equivalencies,nMin,nMax,eps&
      &,fullLab,label,digit,fname,cRange,concCheck) ! Read in parent lattice vectors, etc.
 if (LatDim==3) then; latTyp='b';else;latTyp='s';endif
 call gen_multilattice_derivatives(title, parLV,nD,d,k,nMin,nMax,latTyp,eps,fullLab,&
-         label,digit,equivalencies,concCheck,cRange, polya=.true., oldAlgorithm=oldAlgorithm)
+         label,digit,equivalencies,concCheck,cRange, polya=.true.,&
+         origCrossOutAlgorithm=origCrossOutAlgorithm)
 
 END PROGRAM driver

--- a/src/io_utils.f90
+++ b/src/io_utils.f90
@@ -535,7 +535,7 @@ CONTAINS
        write(99,'("Concentration ranges are specified. Will run with using &
             & the fixed-concentration algorithm.")')
        do i = 1, k
-          write(99,'("Type",i2," conc:",i2,"/",i2,"--",i2,"/",i2)') i,cRange(i,(/1,3/)),cRange(i,2:3)
+          write(99,'("Type",i2," conc:",i2,"/",i2,"--",i2,"/",i2)') i,cRange(i,1),cRange(i,3),cRange(i,2:3)
        enddo
     else
        write(99,'("Concentration ranges are *not* specified. Using &


### PR DESCRIPTION
Changes are in derivative_structure_generator.f90, driver.f90, driver_polya.f90 (this is a quick fix for https://github.com/msg-byu/enumlib/issues/61)

Changes in io_utils.f90 prevent ifort 17.0.1 crash: https://software.intel.com/en-us/forums/intel-visual-fortran-compiler-for-windows/topic/684858