### PR TITLE
Exit gracefully when index is out of range

### DIFF
--- a/src/labeling_related.f90
+++ b/src/labeling_related.f90
@@ -412,6 +412,12 @@ CONTAINS
        if(is_valid_multiplicity(a,iConc)) then ! We have a valid
        ! labeling on the tree, mark it in the
           call generate_index_from_labeling(a,iConc,idxOrig) ! hash
+          
+          if(idxOrig < 0) then
+             ! Out of the integer range, exit
+             stop "Index is too large (integer cannot fit it)"
+          end if
+
           ! table and then mark the symmetry brothers
           if(lab(idxOrig)=='') then ! This labeling hasn't been
                                     ! generated yet (directly or by


### PR DESCRIPTION
Related to: https://github.com/msg-byu/enumlib/issues/67

Example from the #67 now exits as:
```
~/enumlib/src/enum.x enumerate_periodic.in
---------------------------------------------------------------------------------------------
Calculating derivative structures for index n= 1 to  1
Including only structures of which the concentration of each atom is in the range:
Type: 1: 4/76--4/76
Type: 2: 16/76--16/76
Type: 3: 25/76--25/76
Type: 4: 3/76--3/76
Type: 5: 20/76--20/76
Type: 6: 8/76--8/76
Volume       CPU        #HNFs  #SNFs    #reduced    % dups      volTot      RunTot
Original d-set member was not inside the unit cell. It has been remapped.
Original:  9.396   5.593   6.760
Remapped: -0.034   5.593   6.760
Original d-set member was not inside the unit cell. It has been remapped.
Original:  9.396   8.319   6.760
Remapped: -0.034   8.319   6.760
Index is too large (integer cannot fit it)
```