### PR TITLE
Inconsistency on first example in walkthrough.

### DIFF
--- a/support/input/struct_enum.in.fcc
+++ b/support/input/struct_enum.in.fcc
@@ -6,7 +6,7 @@ bulk
  2 -nary case
     1 # Number of points in the multilattice
  0.0000000      0.0000000      0.0000000    0/1   # d01 d-vector
-    8 8   # Starting and ending cell sizes for search
+    1 8   # Starting and ending cell sizes for search
 0.10000000E-06 # Epsilon (finite precision parameter)
 part list of labelings
 1 2 2


### PR DESCRIPTION
EXAMPLES in `support/` asks the user to run this and explains that it will sweep over cell sizes from 1 to 8.  This should be changed to match the walkthrough. Or the walkthrough should be changed. Either one.