### PR TITLE
Fixed bug in `makeStr.py`.

### DIFF
--- a/aux_src/makeStr.py
+++ b/aux_src/makeStr.py
@@ -699,7 +699,7 @@ def _read_enum_out(args):
                 system["nD"] = int(temp.rstrip().split()[0])
             if system["nD"] != 0 and line_count in range(7,7+system["nD"]):
                 vec = [float(v) for v in temp.split() if RepresentsFloat(v)]
-                system["dvecs"].append(vec)
+                system["dvecs"].append(vec[:3])
             if line_count == 7+system["nD"]:
                 system["k"] = int(temp.split('-')[0].strip())
             if line_count == 9 + system["nD"]:


### PR DESCRIPTION
The code was adding an extra coordinate to the atomic basis vectors when the location could only hold a singe element:
```
  0.0000000       0.0000000       0.0000000        # d01 d-vector, labels: 0
```
This was fixed by forcing the vectors to be of length 3, i.e., dropping the extra coordinate if it exist. 