### PR TITLE
Bug fix for problem introduced with inactive site extension

### DIFF
--- a/src/derivative_structure_generator.f90
+++ b/src/derivative_structure_generator.f90
@@ -369,6 +369,8 @@ CONTAINS
   !!<parameter name="shift" regular="true">fractional shifts of the spacegroup.</parameter>
   !!<parameter name="drplist" regular="true">Output. A list of
   !!permutations effected by the Ops.</parameter>
+  !!<parameter name="Latdim" regular="true">2 or 3 dimensional
+  !!case?</parameter>
   !!<parameter name="eps" regular="true">Finite precision
   !!tolerance.</parameter>
 SUBROUTINE get_dvector_permutations(pLV,d,nD,rot,shift,dRPList,eps)
@@ -452,7 +454,7 @@ SUBROUTINE get_dvector_permutations(pLV,d,nD,rot,shift,dRPList,eps)
   !!in the enumeration.</parameter>
   !!<parameter name="surf" regular="true">True is this is a surface
   !!calculation, false otherwise.</parameter>
-  SUBROUTINE get_rotation_perms_lists(A,HNF,L,SNF,Op,RPlist,dperms,eps,aperms,use_arrows, surf)
+  SUBROUTINE get_rotation_perms_lists(A,HNF,L,SNF,Op,RPlist,dperms,eps,aperms,use_arrows,surf)
     real(dp), intent(in) :: A(3,3)
     integer, intent(in), dimension(:,:,:) :: HNF, L, SNF
     type(OpList), intent(in) :: Op(:)
@@ -487,12 +489,14 @@ SUBROUTINE get_dvector_permutations(pLV,d,nD,rot,shift,dRPList,eps)
     end if
 
     ! build the arrow basis.
-    if (present(surf) .and. (surf .eqv. .True.)) then
+    if (present(surf)) then
+      if (surf .eqv. .True.) then
        allocate(arrow_basis(3,4))
        arrow_basis(:,1) = (/1,0,0/)
        arrow_basis(:,2) = (/-1,0,0/)
        arrow_basis(:,3) = (/0,1,0/)
        arrow_basis(:,4) = (/0,-1,0/)
+      endif
     else
        allocate(arrow_basis(3,6))
        arrow_basis(:,1) = (/1,0,0/)
@@ -1267,7 +1271,7 @@ SUBROUTINE get_dvector_permutations(pLV,d,nD,rot,shift,dRPList,eps)
 
     ! Beginning of main routine for enumeration
     open(23,file="VERSION.enum")
-    write(23,'(A)') "v2.0.4-30-g4fc9-dirty"
+    write(23,'(A)') "v2.0.4-40-gfc3d-dirty"
     close(23)
 
     ![TODO] Get rid of all the junk that crept in (writing files, making inactives table, etc. These should all be in routines so that this main routine is still readable)

--- a/src/derivative_structure_generator.f90
+++ b/src/derivative_structure_generator.f90
@@ -529,18 +529,15 @@ SUBROUTINE get_dvector_permutations(pLV,d,nD,rot,shift,dRPList,eps)
     ! Make the group member list for the first SNF
     diag = (/SNF(1,1,1),SNF(2,2,1),SNF(3,3,1)/)
     call make_member_list(diag,g)
-    do im=1,3;write(19,'("Member list: ",3(20(1x,i2)))') g(im,:); enddo
     call matrix_inverse(A,Ainv,err)
     if(err) stop "Invalid parent lattice vectors in get_rotation_perm_lists"
 
     do iH = 1,nH ! loop over each superlattice unless the SNF is
    ! different than the previous (they should be sorted into blocks)
    ! don't bother making the group again. Just use the same one.
-   write(19,'("HNF #: ",i2)') iH
        if(iH > 1) then; if(.not. all(SNF(:,:,ih)==SNF(:,:,ih-1))) then
           diag = (/SNF(1,1,ih),SNF(2,2,ih),SNF(3,3,ih)/)
           call make_member_list(diag,g)
-          write(19,'("Member list: ")') g
        endif; endif
        ! Make the transform matrices for taking the g's and rotating them
        Tinv = matmul(L(:,:,iH),Ainv); call matrix_inverse(Tinv, T, err)
@@ -564,13 +561,11 @@ SUBROUTINE get_dvector_permutations(pLV,d,nD,rot,shift,dRPList,eps)
              if (.not. equal(rgp,nint(rgp),eps)) stop "Transform left big fractional parts"
              gp = nint(rgp) ! Move the rotated group into an integer array
              ag = nint(rag)
-             write(*,'("gp-premod: ",20(1x,i2))')gp
              gp = modulo(gp,spread(diag,2,n)) ! Mod by each entry of
              ! the SNF to bring into group Now that the rotated group
              ! is known, find the mapping of the elements between the
              ! original group and the permuted group. This is the
              ! permutation.
-             write(*,'("gp-pstmod: ",20(1x,i2))')gp
              skip = .false. ! This is just for efficiency
              do im = 1, n
                 do jm = 1, n
@@ -1059,7 +1054,6 @@ SUBROUTINE get_dvector_permutations(pLV,d,nD,rot,shift,dRPList,eps)
     do iRot = 1,nRot  ! Loop over each rotation
         thisRot = rot(:,:,iRot) ! Store the rotation
 !       write(*,'("HNF: ",9(i3,1x))') HNF
-
        rotLat = matmul(thisRot,origLat)          ! Compute the rotated superlattice
        ! do i = 1, size(rot,3)
        !    write(*,'(3("orig:   ",3(f10.6,1x),/))') origLat

--- a/src/enumeration_utilities.f90
+++ b/src/enumeration_utilities.f90
@@ -64,36 +64,26 @@ CONTAINS
 
     integer a, b, c, d, e, f ! elements of the HNF matrix
     integer digit ! one of the labelings in the labeling
-    integer ic, z1, z2, z3 ! Counter over number of interior points, steps in the g table
-    !("lattice coords")
+    integer ic, z1, z2, z3 ! Counter over number of interior points, steps in the g table ("lattice coords")
     integer iAt, i, iD, nD
-    real(dp) :: greal(3)   ! Floating point representation of the group element components
-    !(g-vector)
+    real(dp) :: greal(3)   ! Floating point representation of the group element components (g-vector)
     integer  :: g(3)       ! Integer version of greal
 
     nD = size(pBas,2)
-    !allocate(gotAtomFromLabPos(n*nD)); gotAtomFromLabPos = .false.
 
     ! Define the non-zero elements of the HNF matrix
     a = HNF(1,1); b = HNF(2,1); c = HNF(2,2)
     d = HNF(3,1); e = HNF(3,2); f = HNF(3,3)
     ! Compute the superlattice vectors
-    !write(*,'("Parent lattice:",/,3(3f7.3,1x,/))') (pLV(:,i),i=1,3)
-    !write(*,'("Parent lattice:",/,3(3I,1x,/))') (HNF(i,:),i=1,3)
-
     sLV = matmul(pLV,HNF)
-    !write(*,'("Superlattice:",/,3(3f7.3,1x,/))') (sLV(:,i),i=1,3)
 
     ! Find the coordinates of the basis atoms
     allocate(aBas(3,n*nD))
     allocate(spin(n*nD),gIndx(n*nD))
     gIndx=-1
 
-    !write(*,'(3(f7.3,1x))') (sLV(i,:),i=1,3)
     ! Let's get the fattest basis (Minkowski reduction)
     if (minkowskiReduce) call minkowski_reduce_basis(sLV,sLV,eps)
-    !write(*,'(3(f7.3,1x))') (sLV(i,:),i=1,3)
-
 
     ! Find each atomic position from the g-space information
     ic = 0  ! Keep track of the number of points mapped so far

--- a/src/enumeration_utilities.f90
+++ b/src/enumeration_utilities.f90
@@ -1013,8 +1013,6 @@ CONTAINS
     integer,pointer,dimension(:,:,:) :: HNFin, HNFout, L, R, SNFlist, uqSNF
     type(RotPermList) :: dRotList ! This is a list of permutations for the d-set
     ! (needed as input for several routines)
-    type(RotPermList) :: dRotList ! This is a list of permutations for the d-set (needed as in put for several routines)
-
     type(opList), pointer :: fixOp(:) ! List of symops that fix the superlattice
     type(RotPermList), pointer :: LattRotList(:) ! List of rotation perms for the superlattice
     integer, pointer :: labeling(:), hnf_degen(:)
@@ -1056,7 +1054,7 @@ CONTAINS
     T = matmul(parLattTest,pLV)
     if(.not. equal(T,nint(T),eps)) stop "Input for get_gspace_representation is inconsistent"
     write(17,'("Size of supercell: ",i3)') abs(nint(determinant(sLV)/determinant(pLV)))
-    write(17,'("d-set: ",/,200(3(f7.3,1x),/))') (dset(:,iAt),iAt=1,size(dset,2)
+    write(17,'("d-set: ",/,200(3(f7.3,1x),/))') (dset(:,iAt),iAt=1,size(dset,2))
 
     !** Calls to enumlib routines **
 


### PR DESCRIPTION
pLVtemp should have been pLV in "get_gspace_rep". This caused the HNF to be incorrect which led to the wrong gspace mapping of atomic sites in the supercell