### PR TITLE
Update enumeration_utilities.f90 - get_gspace_representation: 

### DIFF
--- a/src/enumeration_utilities.f90
+++ b/src/enumeration_utilities.f90
@@ -1003,6 +1003,12 @@ CONTAINS
     ! caused an insidious bug that took a long time to fix.
 
     !** Calls to enumlib routines **
+    
+    ! Change pLVtemp to the original basis plV.  
+    pLVtemp = pLV
+
+    ! Apply make primitive one more time.
+    call make_primitive(pLVtemp,aTypTemp,aBasTemp,.false.,eps)
 
     ! This call generates a list of permutations for the d-set under symmetry operations
     ! of the parent lattice (need this for d-g table permutations). This call should use 


### PR DESCRIPTION
Fixed issues where the wrong basis is being used for aBasTemp - this becomes apparent for non-cubic structures. A second make_primitive call with the correct basis is the solution.